### PR TITLE
add validations for WC model

### DIFF
--- a/app/models/wc.rb
+++ b/app/models/wc.rb
@@ -1,3 +1,9 @@
 class Wc < ApplicationRecord
   belongs_to :user
+  #has_many :reviews
+  validates :name, presence: { message: "please give a name to your toilets" }
+  validates :address, presence: { message: "please indicate the address of your toilets" }
+  validates :availability, presence: { message: "you need to indicate whether your toilets are available or not (true or false)" }
+  #validates :name, uniqueness: { scope: :user_id }
+  validates_uniqueness_of :name, :scope => [:user_id]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523102653) do
+ActiveRecord::Schema.define(version: 20170523142355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,4 +47,16 @@ ActiveRecord::Schema.define(version: 20170523102653) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  create_table "wcs", force: :cascade do |t|
+    t.string   "name"
+    t.string   "description"
+    t.string   "address"
+    t.boolean  "availability"
+    t.integer  "user_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["user_id"], name: "index_wcs_on_user_id", using: :btree
+  end
+
+  add_foreign_key "wcs", "users"
 end


### PR DESCRIPTION
add validations with regards of : 
- presence necessary for name, address, availability but not description (considered optional here)
- uniqueness of name vs user_id : any user can have two toilets offered on the website with same address, but they must have distinct names